### PR TITLE
시작날짜 종료날짜 분리 & 조회 변경

### DIFF
--- a/src/main/kotlin/com/todo/deoji/core/domain/todo/dto/request/AddTodoRequestDto.kt
+++ b/src/main/kotlin/com/todo/deoji/core/domain/todo/dto/request/AddTodoRequestDto.kt
@@ -7,5 +7,6 @@ data class AddTodoRequestDto(
     val todoName: String,
     val activeStatus: TodoActiveStatus,
     val categoryId: Long,
-    val runDate: LocalDateTime
+    val startDateTime: LocalDateTime,
+    val endDateTime: LocalDateTime
 )

--- a/src/main/kotlin/com/todo/deoji/core/domain/todo/dto/response/GetMainDataTodoResponseDto.kt
+++ b/src/main/kotlin/com/todo/deoji/core/domain/todo/dto/response/GetMainDataTodoResponseDto.kt
@@ -6,7 +6,8 @@ import java.time.LocalDateTime
 data class GetMainDataTodoResponseDto(
     val id: Long,
     val activeStatus: TodoActiveStatus,
-    val todoDate: LocalDateTime,
+    val startDateTime: LocalDateTime,
+    val endDateTime: LocalDateTime,
     val todoName: String,
     val categoryName: String,
     val categoryColorCode: String

--- a/src/main/kotlin/com/todo/deoji/core/domain/todo/model/Todo.kt
+++ b/src/main/kotlin/com/todo/deoji/core/domain/todo/model/Todo.kt
@@ -8,6 +8,7 @@ data class Todo(
     val name: String,
     val sort: Int,
     val activeStatus: TodoActiveStatus,
-    val runDate: LocalDateTime,
+    val startDateTime: LocalDateTime,
+    val endDateTime: LocalDateTime,
     val category: Category
 )

--- a/src/main/kotlin/com/todo/deoji/core/domain/todo/spi/QueryTodoPort.kt
+++ b/src/main/kotlin/com/todo/deoji/core/domain/todo/spi/QueryTodoPort.kt
@@ -7,7 +7,16 @@ import com.todo.deoji.core.domain.user.model.User
 import java.time.LocalDateTime
 
 interface QueryTodoPort {
-    fun findMaxSortByCategoryAndRunDate(category: Category, runDate: LocalDateTime): Int
-    fun findAllByMonthAndYearAndUser(month: Int, year: Int, user: User): List<GetMainDataTodoResponseDto>
+    fun findMaxSortByCategoryAndStartDateAndEndDate(
+        category: Category,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): Int
+
+    fun findAllByMonthAndYearAndUser(
+        month: Int, year: Int, lastDayOfMonth: Int,
+        user: User
+    ): List<GetMainDataTodoResponseDto>
+
     fun findAllByCategoryIdsAndMonthAndYear(categoryIds: List<Long>, month: Int, year: Int): List<Todo>
 }

--- a/src/main/kotlin/com/todo/deoji/core/domain/todo/usecase/AddTodoUseCase.kt
+++ b/src/main/kotlin/com/todo/deoji/core/domain/todo/usecase/AddTodoUseCase.kt
@@ -19,8 +19,13 @@ class AddTodoUseCase(
                         id = 0,
                         name = addTodoRequestDto.todoName,
                         activeStatus = addTodoRequestDto.activeStatus,
-                        runDate = addTodoRequestDto.runDate,
-                        sort = todoPort.findMaxSortByCategoryAndRunDate(category, addTodoRequestDto.runDate) + 1,
+                        startDateTime = addTodoRequestDto.startDateTime,
+                        endDateTime = addTodoRequestDto.endDateTime,
+                        sort = todoPort.findMaxSortByCategoryAndStartDateAndEndDate(
+                            category,
+                            addTodoRequestDto.startDateTime,
+                            addTodoRequestDto.endDateTime
+                        ) + 1,
                         category = category
                     )
                 )

--- a/src/main/kotlin/com/todo/deoji/core/domain/todo/usecase/GetTodoMainListUseCase.kt
+++ b/src/main/kotlin/com/todo/deoji/core/domain/todo/usecase/GetTodoMainListUseCase.kt
@@ -49,7 +49,7 @@ class GetTodoMainListUseCase(
                 categoryDataList = categoryList.mapNotNull { category ->
                     // 현재 날짜(day)에 해당하는 todo만 필터링
                     val groupedTodos = todoByCategory[category.id]
-                        ?.filter { it.runDate.dayOfMonth == day }
+                        ?.filter { it.startDateTime.dayOfMonth == day }
                         .orEmpty()
 
                     // 만약 해당 날짜에 해당하는 투두가 없으면 null 처리 (mapNotNull에서 자동 제거됨)

--- a/src/main/kotlin/com/todo/deoji/core/domain/todo/usecase/GetTodoMainUseCase.kt
+++ b/src/main/kotlin/com/todo/deoji/core/domain/todo/usecase/GetTodoMainUseCase.kt
@@ -16,16 +16,32 @@ class GetTodoMainUseCase(
         // 년과 월을 받아서 달에
         getCurrentUserService.getCurrentUser()
             .let { user ->
-                todoPort.findAllByMonthAndYearAndUser(month, year, user)
-                    .let { todoDataList ->
-                        YearMonth.of(year, month).lengthOfMonth()
-                            .let { totalDay ->
+                YearMonth.of(year, month).lengthOfMonth()
+                    .let { totalDay ->
+                        todoPort.findAllByMonthAndYearAndUser(month, year, totalDay, user)
+                            .let { todoDataList ->
                                 (1..totalDay)
                                     .map { day ->
                                         GetMainDataResponseDto(
                                             day = String.format("%04d-%02d-%02d", year, month, day),
                                             todoList = todoDataList
-                                                .filter { it.todoDate.dayOfMonth == day }
+                                                .filter {
+                                                    val startDay = it.startDateTime.dayOfMonth
+                                                    val endDay = it.endDateTime.dayOfMonth
+
+                                                    //시작일이 해당 월 이전이고 종료일이 해당 월이면
+                                                    if (it.startDateTime.year < year || (it.startDateTime.year == year && it.startDateTime.monthValue < month)) {
+                                                        day in 1..endDay
+                                                    }
+                                                    //시작일이 해당 월이고 종료일이 해당 월 이후면
+                                                    else if (it.endDateTime.year > year || (it.endDateTime.year == year && it.endDateTime.monthValue > month)) {
+                                                        day in startDay..totalDay
+                                                    }
+                                                    //시작일과 종료일이 모두 해당 월 안에 있으면
+                                                    else {
+                                                        day in startDay..endDay
+                                                    }
+                                                }
                                         )
                                     }
                             }

--- a/src/main/kotlin/com/todo/deoji/persistence/todo/TodoPersistenceAdapter.kt
+++ b/src/main/kotlin/com/todo/deoji/persistence/todo/TodoPersistenceAdapter.kt
@@ -21,11 +21,18 @@ class TodoPersistenceAdapter(
     override fun save(todo: Todo): Todo =
         todoJpaRepository.save(todo.toEntity()).toDomain()
 
-    override fun findMaxSortByCategoryAndRunDate(category: Category, runDate: LocalDateTime): Int =
-        todoCustomRepository.findMaxSortByCategoryAndRunDate(category, runDate)
+    override fun findMaxSortByCategoryAndStartDateAndEndDate(
+        category: Category,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): Int =
+        todoCustomRepository.findMaxSortByCategoryAndStartDateAndEndDate(category, startDate, endDate)
 
-    override fun findAllByMonthAndYearAndUser(month: Int, year: Int, user: User): List<GetMainDataTodoResponseDto> =
-        todoCustomRepository.findAllByMonthAndYearAndUser(month, year, user.toEntity())
+    override fun findAllByMonthAndYearAndUser(
+        month: Int, year: Int, lastDayOfMonth: Int,
+        user: User
+    ): List<GetMainDataTodoResponseDto> =
+        todoCustomRepository.findAllByMonthAndYearAndUser(month, year, lastDayOfMonth, user.toEntity())
 
     override fun findAllByCategoryIdsAndMonthAndYear(
         categoryIds: List<Long>,

--- a/src/main/kotlin/com/todo/deoji/persistence/todo/adapter/TodoAdapter.kt
+++ b/src/main/kotlin/com/todo/deoji/persistence/todo/adapter/TodoAdapter.kt
@@ -11,7 +11,8 @@ fun TodoJpaEntity.toDomain() =
         name = this.name,
         sort = this.sort,
         activeStatus = this.activeStatus,
-        runDate = this.runDate,
+        startDateTime = this.startDateTime,
+        endDateTime = this.endDateTime,
         category = this.category.toDomain()
     )
 
@@ -21,6 +22,7 @@ fun Todo.toEntity() =
         name = this.name,
         sort = this.sort,
         activeStatus = this.activeStatus,
-        runDate = this.runDate,
+        startDateTime = this.startDateTime,
+        endDateTime = this.endDateTime,
         category = this.category.toEntity()
     )

--- a/src/main/kotlin/com/todo/deoji/persistence/todo/entity/TodoJpaEntity.kt
+++ b/src/main/kotlin/com/todo/deoji/persistence/todo/entity/TodoJpaEntity.kt
@@ -16,7 +16,8 @@ class TodoJpaEntity(
     val sort: Int,
     @Enumerated(EnumType.STRING)
     val activeStatus: TodoActiveStatus,
-    val runDate: LocalDateTime,
+    val startDateTime: LocalDateTime,
+    val endDateTime: LocalDateTime,
     @ManyToOne
     @JoinColumn(name = "category_id", nullable = false)
     val category: CategoryJpaEntity

--- a/src/main/kotlin/com/todo/deoji/persistence/todo/repository/TodoCustomRepository.kt
+++ b/src/main/kotlin/com/todo/deoji/persistence/todo/repository/TodoCustomRepository.kt
@@ -10,7 +10,16 @@ import java.time.LocalDateTime
 
 @Repository
 interface TodoCustomRepository {
-    fun findMaxSortByCategoryAndRunDate(category: Category, runDate: LocalDateTime): Int
-    fun findAllByMonthAndYearAndUser(month: Int, year: Int, user: UserJpaEntity): List<GetMainDataTodoResponseDto>
+    fun findMaxSortByCategoryAndStartDateAndEndDate(
+        category: Category,
+        startDate: LocalDateTime,
+        endDate: LocalDateTime
+    ): Int
+
+    fun findAllByMonthAndYearAndUser(
+        month: Int, year: Int, lastDayOfMonth: Int,
+        user: UserJpaEntity
+    ): List<GetMainDataTodoResponseDto>
+
     fun findAllByCategoryAndMonthAndYear(categoryIds: List<Long>, month: Int, year: Int): List<TodoJpaEntity>
 }

--- a/src/main/kotlin/com/todo/deoji/presentation/domain/todo/data/extension/TodoRequestExtension.kt
+++ b/src/main/kotlin/com/todo/deoji/presentation/domain/todo/data/extension/TodoRequestExtension.kt
@@ -7,6 +7,7 @@ fun AddTodoRequestData.toAddTodoRequestDto(): AddTodoRequestDto =
     AddTodoRequestDto(
         todoName = this.todoName,
         activeStatus = this.activeStatus,
-        runDate = this.runDate,
+        startDateTime = this.startDate,
+        endDateTime = this.endDate,
         categoryId = this.categoryId
     )

--- a/src/main/kotlin/com/todo/deoji/presentation/domain/todo/data/extension/TodoRequestExtension.kt
+++ b/src/main/kotlin/com/todo/deoji/presentation/domain/todo/data/extension/TodoRequestExtension.kt
@@ -7,7 +7,7 @@ fun AddTodoRequestData.toAddTodoRequestDto(): AddTodoRequestDto =
     AddTodoRequestDto(
         todoName = this.todoName,
         activeStatus = this.activeStatus,
-        startDateTime = this.startDate,
-        endDateTime = this.endDate,
+        startDateTime = this.startDateTime,
+        endDateTime = this.endDateTime,
         categoryId = this.categoryId
     )

--- a/src/main/kotlin/com/todo/deoji/presentation/domain/todo/data/request/AddTodoRequestData.kt
+++ b/src/main/kotlin/com/todo/deoji/presentation/domain/todo/data/request/AddTodoRequestData.kt
@@ -7,6 +7,6 @@ data class AddTodoRequestData(
     val todoName: String,
     val activeStatus: TodoActiveStatus,
     val categoryId: Long,
-    val startDate: LocalDateTime,
-    val endDate: LocalDateTime
+    val startDateTime: LocalDateTime,
+    val endDateTime: LocalDateTime
 )

--- a/src/main/kotlin/com/todo/deoji/presentation/domain/todo/data/request/AddTodoRequestData.kt
+++ b/src/main/kotlin/com/todo/deoji/presentation/domain/todo/data/request/AddTodoRequestData.kt
@@ -7,5 +7,6 @@ data class AddTodoRequestData(
     val todoName: String,
     val activeStatus: TodoActiveStatus,
     val categoryId: Long,
-    val runDate: LocalDateTime
+    val startDate: LocalDateTime,
+    val endDate: LocalDateTime
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
  - 투두 항목에 대해 단일 날짜 대신 시작 시간과 종료 시간을 별도로 입력할 수 있어, 일정 관리와 조회가 더욱 명확해졌습니다.

- **리팩터**
  - 일정 필터링 및 정렬 로직이 개선되어, 월별 및 사용자별 투두 항목의 스케줄이 더욱 정교하게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->